### PR TITLE
WEB-34 Wrap up bamboo build and deploy. Simplify code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ npm run test:links -- http://numenta.com
 
 # Websites
 
+**Please change directories to one of the individual website sources, i.e.:**
+
+```shell
+cd packages/numenta.com/
+```
+
+**The rest of this section will assume you are in one of the website
+sub-directories.**
+
 ## Goals
 
 These sites are an attempt at getting back to the roots of the web: *reading*.
@@ -375,9 +384,10 @@ example, see the local file `.eslintrc.json`).
 * Each `React` Component should return 1 small element
 * Include spaces manually around React Elements in JSX with: `{' '}`
 * Custom [React context](https://facebook.github.io/react/docs/context.html)
-  which is available:
-  * `config` = Site config (see: `config.toml`).
-  * `manifest` = Site `package.json` manifest vars like `repo` and 'version`
+  which is available (in addition to Gatsby defaults):
+  * `config` = Site config object (see: `config.toml`).
+  * `manifest` = Site `package.json` manifest object vars like `repo`, 'version`
+  * `stamp` = Build start timestamp string (for cache-busting)
 * Make sure to use the `prefixLink()` helper function on all internal links.
   This should be handled auto-magically for you already, but if you have trouble
   with links on staging, this may be the problem
@@ -440,16 +450,9 @@ example, see the local file `.eslintrc.json`).
 
 ### Packages
 
-* Use exact versions for dependencies in `package.json`, no version RegExps
-  please. All package changes need be exact and on purpose for build
-  reproducibility. `npm` has a `--save-exact` parameter for this:
-  ```
-  npm install package@1.2.34 --save --save-exact
-  npm install other@5.6.7 --save-dev --save-exact
-  ```
-* Bump version number with each changeset: `npm version patch`
-* Keep packages as up-to-date as possible. Check with: `npm outdated -depth 0`
-* Update and test 1 package at a time
+* Use exact versions for dependencies in `package.json`
+* Keep packages as up-to-date as possible: `npm outdated -depth 0`
+* Update and test 1 package at a time for safety
 
 ### Styles
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,9 @@
-- Version bump after builds
-- Production deployments
-- Update new rewrites to new style for new sites
+
 - Docs/training
   - Where are rewrites
-- .Org ready for code handoff to Matt
+- .Org ready for code handoff to Matt / MD!
 
+- why Common `require/module.exports` over ES6 `import/export` modules
 - .ORG FAQ PAGE!?
 - Shared `/components` need to have theme style vars passed in from each site
   independently somehow. `theme.css` global what to do?

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,8 @@
-
 - Docs/training
   - Where are rewrites
 - .Org ready for code handoff to Matt / MD!
 
-- why Common `require/module.exports` over ES6 `import/export` modules
+
 - .ORG FAQ PAGE!?
 - Shared `/components` need to have theme style vars passed in from each site
   independently somehow. `theme.css` global what to do?

--- a/__tests__/__mocks__/reactContextMock.js
+++ b/__tests__/__mocks__/reactContextMock.js
@@ -12,7 +12,6 @@ const context = {
       type: 'git',
       url: 'https://github.com/numenta/numenta-web',
     },
-    version: '0.0.1',
   },
   route: {
     page: post,
@@ -28,6 +27,7 @@ const context = {
     replace() {},
     setRouteLeaveHook() {},
   },
+  stamp: '1318874398',  // moment().unix().toString()
 }
 
 

--- a/packages/components/src/Footer/__tests__/__snapshots__/index.unit.test.jsx.snap
+++ b/packages/components/src/Footer/__tests__/__snapshots__/index.unit.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`Footer React component Renders correctly 1`] = `
     className="footer">
     <span>
       © 
-      2016
+      2017
        
        
       <a

--- a/packages/components/src/ImageLink/index.jsx
+++ b/packages/components/src/ImageLink/index.jsx
@@ -6,9 +6,9 @@ import {IndexLink, Link} from 'react-router'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
 
-import {triggerGAnalyticsEvent} from 'numenta-web-shared-utils/lib/client'
-
 import styles from './index.css'
+
+const {triggerGAnalyticsEvent} = require('numenta-web-shared-utils/client')
 
 
 /**

--- a/packages/components/src/Markdown/index.jsx
+++ b/packages/components/src/Markdown/index.jsx
@@ -8,9 +8,9 @@ import React from 'react'
 import root from 'window-or-global'
 import url from 'url'
 
-import {triggerGAnalyticsEvent} from 'numenta-web-shared-utils/lib/client'
-
 import styles from './index.css'
+
+const {triggerGAnalyticsEvent} = require('numenta-web-shared-utils/client')
 
 
 /**

--- a/packages/components/src/Pingdom/index.jsx
+++ b/packages/components/src/Pingdom/index.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react'
 
-import {trims} from 'numenta-web-shared-utils/lib/shared'
+const {trims} = require('numenta-web-shared-utils/universal')
 
 
 /**

--- a/packages/components/src/PostListItem/index.jsx
+++ b/packages/components/src/PostListItem/index.jsx
@@ -2,7 +2,6 @@
 // MIT License (see LICENSE.txt)
 // Copyright © 2005—2017 Numenta <http://numenta.com>
 
-import {getEventTimeDisplay} from 'numenta-web-shared-utils/lib/shared'
 import moment from 'moment'
 import React from 'react'
 
@@ -19,6 +18,8 @@ import TextLink from '../TextLink'
 import Time from '../Time'
 
 import styles from './index.css'
+
+const {getEventTimeDisplay} = require('numenta-web-shared-utils/universal')
 
 
 /**

--- a/packages/components/src/Search/index.jsx
+++ b/packages/components/src/Search/index.jsx
@@ -8,6 +8,7 @@ import lunr from 'lunr'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
 import request from 'superagent'
+import root from 'window-or-global'
 
 import Button from '../Button'
 import Form from '../Form'
@@ -78,6 +79,7 @@ class Search extends React.Component {
   }
 
   render() {
+    const {document} = root
     const {query} = this.state
     let {icon} = this.props
     let matches, results
@@ -95,7 +97,7 @@ class Search extends React.Component {
       results = (
         <SearchResult
           onClose={() => this._performSearch('')}
-          onOpen={() => global.document.getElementById('q').focus()}
+          onOpen={() => document.getElementById('q').focus()}
           query={query}
           results={matches}
         />

--- a/packages/components/src/Search/index.jsx
+++ b/packages/components/src/Search/index.jsx
@@ -8,7 +8,6 @@ import lunr from 'lunr'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
 import request from 'superagent'
-import {stampUrl} from 'numenta-web-shared-utils/lib/shared'
 
 import Button from '../Button'
 import Form from '../Form'
@@ -17,6 +16,8 @@ import FormLabel from '../FormLabel'
 import SearchResult from '../SearchResult'
 
 import styles from './index.css'
+
+const {stampUrl} = require('numenta-web-shared-utils/universal')
 
 
 /**
@@ -27,7 +28,7 @@ import styles from './index.css'
 class Search extends React.Component {
 
   static contextTypes = {
-    manifest: React.PropTypes.object.isRequired,
+    stamp: React.PropTypes.string.isRequired,
   }
 
   static propTypes = {
@@ -50,11 +51,10 @@ class Search extends React.Component {
   }
 
   componentDidMount() {
-    const {manifest} = this.context
-    const {version} = manifest
+    const {stamp} = this.context
 
     request
-      .get(prefixLink(stampUrl('/_searchIndex.json', version)))  // load index
+      .get(prefixLink(stampUrl('/_searchIndex.json', stamp)))  // load index
       .set('Accept', 'application/json')
       .end((error, results) => {
         if (error || !results || !('body' in results)) return

--- a/packages/components/src/SearchResult/index.jsx
+++ b/packages/components/src/SearchResult/index.jsx
@@ -2,8 +2,6 @@
 // MIT License (see LICENSE.txt)
 // Copyright © 2005—2017 Numenta <http://numenta.com>
 
-import {getBrowserWidth} from 'numenta-web-shared-utils/lib/client'
-import {getModalWidth} from 'numenta-web-shared-utils/lib/shared'
 import unescape from 'lodash/unescape'
 import Highlight from 'react-highlighter'
 import Modal from 'react-modal'
@@ -19,6 +17,9 @@ import TextLink from '../TextLink'
 
 import modalStyles from './_style-modal'
 import styles from './index.css'
+
+const {getBrowserWidth} = require('numenta-web-shared-utils/client')
+const {getModalWidth} = require('numenta-web-shared-utils/universal')
 
 const filterText = (text) => unescape(text)
   .replace(/&#x27;/g, '')

--- a/packages/components/src/Section/index.jsx
+++ b/packages/components/src/Section/index.jsx
@@ -8,11 +8,11 @@ import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
 import root from 'window-or-global'
 
-import {hasSessionStorage} from 'numenta-web-shared-utils/lib/client'
-
 import SectionTitle from '../SectionTitle'
 
 import styles from './index.css'
+
+const {hasSessionStorage} = require('numenta-web-shared-utils/client')
 
 
 /**

--- a/packages/components/src/TextLink/index.jsx
+++ b/packages/components/src/TextLink/index.jsx
@@ -6,9 +6,9 @@ import {IndexLink, Link} from 'react-router'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
 
-import {triggerGAnalyticsEvent} from 'numenta-web-shared-utils/lib/client'
-
 import styles from './index.css'
+
+const {triggerGAnalyticsEvent} = require('numenta-web-shared-utils/client')
 
 
 /**

--- a/packages/components/src/Video/index.jsx
+++ b/packages/components/src/Video/index.jsx
@@ -2,8 +2,6 @@
 // MIT License (see LICENSE.txt)
 // Copyright © 2005—2017 Numenta <http://numenta.com>
 
-import {getBrowserWidth} from 'numenta-web-shared-utils/lib/client'
-import {getModalWidth} from 'numenta-web-shared-utils/lib/shared'
 import IconClose from 'react-icons/lib/fa/close'
 import Modal from 'react-modal'
 import React from 'react'
@@ -13,6 +11,9 @@ import Image from '../Image'
 
 import modalStyles from './_style-modal'
 import styles from './index.css'
+
+const {getBrowserWidth} = require('numenta-web-shared-utils/client')
+const {getModalWidth} = require('numenta-web-shared-utils/universal')
 
 
 /**

--- a/packages/numenta.com/components/Layout/__tests__/__snapshots__/index.unit.test.jsx.snap
+++ b/packages/numenta.com/components/Layout/__tests__/__snapshots__/index.unit.test.jsx.snap
@@ -94,7 +94,7 @@ exports[`Layout React component Renders correctly 1`] = `
       className="footer">
       <span>
         © 
-        2016
+        2017
          
          
         <a

--- a/packages/numenta.com/components/PostListRow/index.jsx
+++ b/packages/numenta.com/components/PostListRow/index.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react'
 
-import {getVideoIdFromUrl} from 'numenta-web-shared-utils/lib/shared'
 import Image from 'numenta-web-shared-components/lib/Image'
 import ImageLink from 'numenta-web-shared-components/lib/ImageLink'
 import PostListItem from 'numenta-web-shared-components/lib/PostListItem'
@@ -12,9 +11,11 @@ import Video from 'numenta-web-shared-components/lib/Video'
 
 import styles from './index.css'
 
+const {getVideoIdFromUrl} = require('numenta-web-shared-utils/universal')
+
 
 /**
- *
+ * Numenta.com Post ListRow - React view component.
  */
 const PostListRow = ({post}) => {
   const {data, path} = post

--- a/packages/numenta.com/gatsby-browser.js
+++ b/packages/numenta.com/gatsby-browser.js
@@ -3,7 +3,8 @@
 // Copyright © 2005—2017 Numenta <http://numenta.com>
 
 import root from 'window-or-global'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 
 /**

--- a/packages/numenta.com/html.jsx
+++ b/packages/numenta.com/html.jsx
@@ -3,13 +3,15 @@
 // Copyright © 2005—2017 Numenta <http://numenta.com>
 
 import {config} from 'config'
-import {stampUrl} from 'numenta-web-shared-utils/lib/shared'
 import Helmet from 'react-helmet'
+import moment from 'moment'
 import Pingdom from 'numenta-web-shared-components/lib/Pingdom'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
 
-import {version} from './package'
+const {stampUrl} = require('numenta-web-shared-utils/universal')
+
+global.stamp = moment().unix().toString()
 
 
 /**
@@ -21,6 +23,7 @@ import {version} from './package'
  * @requires gatsby react
  */
 const HtmlDocument = ({body}) => {
+  const {stamp} = global
   const {analytics} = config
   const {htmlAttributes, link, meta, title} = Helmet.rewind()
   const attrs = htmlAttributes.toComponent()
@@ -36,7 +39,7 @@ const HtmlDocument = ({body}) => {
       </head>
       <body className="body">
         <div id="react-mount" dangerouslySetInnerHTML={{__html: body}} />
-        <script src={prefixLink(stampUrl('/bundle.js', version))} />
+        <script src={prefixLink(stampUrl('/bundle.js', stamp))} />
       </body>
     </html>
   )

--- a/packages/numenta.com/html.jsx
+++ b/packages/numenta.com/html.jsx
@@ -4,26 +4,24 @@
 
 import {config} from 'config'
 import Helmet from 'react-helmet'
-import moment from 'moment'
 import Pingdom from 'numenta-web-shared-components/lib/Pingdom'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
+import root from 'window-or-global'
 
 const {stampUrl} = require('numenta-web-shared-utils/universal')
 
-global.stamp = moment().unix().toString()
-
 
 /**
- * Main Numenta.com HTML5 Document skeleton - React view component.
- *  Base file for Gatsby.js framework.
+ * Main Numenta.com HTML5 Document skeleton - React view component. Base file
+ *  for Gatsby.js framework.
  * @author Numenta <info@numenta.com>
  * @copyright © 2005—2017 Numenta <http://numenta.com>
  * @license MIT
  * @requires gatsby react
  */
 const HtmlDocument = ({body}) => {
-  const {stamp} = global
+  const {STAMP} = root
   const {analytics} = config
   const {htmlAttributes, link, meta, title} = Helmet.rewind()
   const attrs = htmlAttributes.toComponent()
@@ -39,7 +37,7 @@ const HtmlDocument = ({body}) => {
       </head>
       <body className="body">
         <div id="react-mount" dangerouslySetInnerHTML={{__html: body}} />
-        <script src={prefixLink(stampUrl('/bundle.js', stamp))} />
+        <script src={prefixLink(stampUrl('/bundle.js', STAMP))} />
       </body>
     </html>
   )

--- a/packages/numenta.com/package.json
+++ b/packages/numenta.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "numenta-web-site-com",
-  "version": "0.2.211",
+  "version": "0.0.0",
   "description": "Numenta.com company website content, source code, and static generator tooling",
   "license": "MIT",
   "main": false,

--- a/packages/numenta.com/pages/_MainSections.jsx
+++ b/packages/numenta.com/pages/_MainSections.jsx
@@ -6,7 +6,6 @@ import findIndex from 'lodash/findIndex'
 import React from 'react'
 import root from 'window-or-global'
 
-import {hasSessionStorage} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import SectionAnomaly from './anomaly-detection-benchmark/_Section'
@@ -21,6 +20,8 @@ import SectionOpensource from './open-source-community/_Section'
 import SectionPapers from './papers-videos-and-more/_Section'
 import SectionPartners from './partners/_Section'
 import SectionTechnology from './machine-intelligence-technology/_Section'
+
+const {hasSessionStorage} = require('numenta-web-shared-utils/client')
 
 const mainSectionList = [
   {

--- a/packages/numenta.com/pages/_template.jsx
+++ b/packages/numenta.com/pages/_template.jsx
@@ -13,7 +13,6 @@ import mapValues from 'lodash/mapValues'
 import moment from 'moment'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
-import {stampUrl} from 'numenta-web-shared-utils/lib/shared'
 import values from 'lodash/values'
 
 import Layout from '../components/Layout'
@@ -21,6 +20,8 @@ import manifest from '../package'
 
 import 'tachyons-base/css/tachyons-base.css'  // eslint-disable-line import/first, max-len
 import '../static/assets/css/fonts.css'
+
+const {stampUrl} = require('numenta-web-shared-utils/universal')
 
 
 /**
@@ -38,18 +39,21 @@ class Template extends React.Component {
     config: React.PropTypes.object,
     manifest: React.PropTypes.object,
     route: React.PropTypes.object,
+    stamp: React.PropTypes.string,
   }
 
   getChildContext() {
+    const {stamp} = global
     const {route} = this.props
-    return {config, manifest, route}
+    return {config, manifest, route, stamp}
   }
 
   componentDidMount() {
-    if (global.window) injectTapEventPlugin()  // remove @ React 1.0
+    if ('window' in global) injectTapEventPlugin()  // remove @ React 1.0
   }
 
   render() {
+    const {stamp} = global
     const {children} = this.props
     const {analytics, company, description, siteHost} = config
     const lang = 'en'  // @TODO i18n l10n
@@ -57,7 +61,6 @@ class Template extends React.Component {
     const title = `${siteHost} • ${description}`
     const titleForm = `${siteHost} • %s`
     const icons = flatten(values(mapValues(favicons, (value) => keys(value))))
-    const {version} = manifest
 
     // react-helmet / head
     const attrs = {lang}
@@ -71,7 +74,7 @@ class Template extends React.Component {
       {name: 'keywords', content: title.split(' ').join(',')},
       {
         name: 'generator',
-        content: `© ${siteHost} v${version} ${now} • Gatsby.js`,
+        content: `© ${siteHost} v${stamp} ${now} • Gatsby.js`,
       },
     ]
 
@@ -79,7 +82,7 @@ class Template extends React.Component {
     if (process.env.NODE_ENV === 'production') {
       links.push({
         rel: 'stylesheet',
-        href: prefixLink(stampUrl('/styles.css', version)),
+        href: prefixLink(stampUrl('/styles.css', stamp)),
       })
     }
 

--- a/packages/numenta.com/pages/_template.jsx
+++ b/packages/numenta.com/pages/_template.jsx
@@ -13,6 +13,7 @@ import mapValues from 'lodash/mapValues'
 import moment from 'moment'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
+import root from 'window-or-global'
 import values from 'lodash/values'
 
 import Layout from '../components/Layout'
@@ -23,10 +24,12 @@ import '../static/assets/css/fonts.css'
 
 const {stampUrl} = require('numenta-web-shared-utils/universal')
 
+root.STAMP = moment().unix().toString()  // global! cache-busting id
+
 
 /**
- * Root Gatsby Template, acts as React-router bridge (per Gatsby), and internal
- *  Layout and Headmatter manager.
+ * Numenta.com Root Gatsby Template, acts as React-router bridge (per Gatsby),
+ *  and internal Layout and Headmatter manager - a React view component.
  */
 class Template extends React.Component {
 
@@ -43,9 +46,9 @@ class Template extends React.Component {
   }
 
   getChildContext() {
-    const {stamp} = global
+    const {STAMP} = root
     const {route} = this.props
-    return {config, manifest, route, stamp}
+    return {config, manifest, route, stamp: STAMP}
   }
 
   componentDidMount() {
@@ -53,7 +56,7 @@ class Template extends React.Component {
   }
 
   render() {
-    const {stamp} = global
+    const {STAMP} = root
     const {children} = this.props
     const {analytics, company, description, siteHost} = config
     const lang = 'en'  // @TODO i18n l10n
@@ -74,7 +77,7 @@ class Template extends React.Component {
       {name: 'keywords', content: title.split(' ').join(',')},
       {
         name: 'generator',
-        content: `© ${siteHost} v${stamp} ${now} • Gatsby.js`,
+        content: `© ${now} ${siteHost} v=${STAMP} x Gatsby.js`,
       },
     ]
 
@@ -82,7 +85,7 @@ class Template extends React.Component {
     if (process.env.NODE_ENV === 'production') {
       links.push({
         rel: 'stylesheet',
-        href: prefixLink(stampUrl('/styles.css', stamp)),
+        href: prefixLink(stampUrl('/styles.css', STAMP)),
       })
     }
 

--- a/packages/numenta.com/pages/anomaly-detection-benchmark/index.jsx
+++ b/packages/numenta.com/pages/anomaly-detection-benchmark/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionAnomaly from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionAnomaly key="sectionAnomaly" />)
 const title = 'Anomaly Detection Benchmark'

--- a/packages/numenta.com/pages/applications/index.jsx
+++ b/packages/numenta.com/pages/applications/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionApplications from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionApplications key="sectionApplications" />)
 const title = 'Applications'

--- a/packages/numenta.com/pages/blog/index.jsx
+++ b/packages/numenta.com/pages/blog/index.jsx
@@ -8,9 +8,10 @@ import React from 'react'
 import ListItem from 'numenta-web-shared-components/lib/ListItem'
 import ListOrder from 'numenta-web-shared-components/lib/List'
 import Section from 'numenta-web-shared-components/lib/Section'
-import {sortDateDescend} from 'numenta-web-shared-utils/lib/shared'
 
 import PostListRow from '../../components/PostListRow'
+
+const {sortDateDescend} = require('numenta-web-shared-utils/universal')
 
 const title = 'Blog'
 

--- a/packages/numenta.com/pages/business-strategy-and-ip/index.jsx
+++ b/packages/numenta.com/pages/business-strategy-and-ip/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionBusiness from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionBusiness key="sectionBusiness" />)
 const title = 'Business Strategy & IP'

--- a/packages/numenta.com/pages/careers-and-team/_Section.jsx
+++ b/packages/numenta.com/pages/careers-and-team/_Section.jsx
@@ -12,8 +12,6 @@ import Paragraph from 'numenta-web-shared-components/lib/Paragraph'
 import SubTitle from 'numenta-web-shared-components/lib/SubTitle'
 import TextLink from 'numenta-web-shared-components/lib/TextLink'
 
-import {sortDateDescend} from 'numenta-web-shared-utils/lib/shared'
-
 import ImageCareers from './images/careers.png'
 import ImageCeleste from './images/team/celeste-baranski.png'
 import ImageDonna from './images/team/donna-dubinsky.jpg'
@@ -23,6 +21,8 @@ import ImageJeff from './images/team/jeff-hawkins.jpg'
 import ImageMike from './images/team/mike-farmwald.jpg'
 import ImageSubutai from './images/team/subutai-ahmad.jpg'
 import styles from './index.css'
+
+const {sortDateDescend} = require('numenta-web-shared-utils/universal')
 
 
 /**

--- a/packages/numenta.com/pages/careers-and-team/index.jsx
+++ b/packages/numenta.com/pages/careers-and-team/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionCareers from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionCareers key="sectionCareers" />)
 const title = 'Careers & Team'

--- a/packages/numenta.com/pages/contact/index.jsx
+++ b/packages/numenta.com/pages/contact/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections from '../_MainSections'
 import SectionContact from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionContact key="sectionContact" />)
 const title = 'Contact'

--- a/packages/numenta.com/pages/events/index.jsx
+++ b/packages/numenta.com/pages/events/index.jsx
@@ -11,12 +11,13 @@ import ListItem from 'numenta-web-shared-components/lib/ListItem'
 import ListOrder from 'numenta-web-shared-components/lib/List'
 import Section from 'numenta-web-shared-components/lib/Section'
 import SubTitle from 'numenta-web-shared-components/lib/SubTitle'
-import {
-  sortDateAscend, sortDateDescend,
-} from 'numenta-web-shared-utils/lib/shared'
 
 import PostListRow from '../../components/PostListRow'
 import styles from './index.css'
+
+const {
+  sortDateAscend, sortDateDescend,
+} = require('numenta-web-shared-utils/universal')
 
 const title = 'Events'
 

--- a/packages/numenta.com/pages/htm-studio/index.jsx
+++ b/packages/numenta.com/pages/htm-studio/index.jsx
@@ -24,8 +24,6 @@ import FormInput from 'numenta-web-shared-components/lib/FormInput'
 import FormLabel from 'numenta-web-shared-components/lib/FormLabel'
 import FormRow from 'numenta-web-shared-components/lib/FormRow'
 import FormTextArea from 'numenta-web-shared-components/lib/FormTextArea'
-import {getBrowserWidth} from 'numenta-web-shared-utils/lib/client'
-import {getModalWidth} from 'numenta-web-shared-utils/lib/shared'
 import Image from 'numenta-web-shared-components/lib/Image'
 import List from 'numenta-web-shared-components/lib/List'
 import ListItem from 'numenta-web-shared-components/lib/ListItem'
@@ -48,6 +46,9 @@ import ImageVideoWalkthru from './images/video-walkthru.png'
 import modalStyles from './_style-modal'
 import styles from './index.css'
 import Terms from './terms.md'
+
+const {getBrowserWidth} = require('numenta-web-shared-utils/client')
+const {getModalWidth} = require('numenta-web-shared-utils/universal')
 
 const title = 'HTM Studio'
 const URL_OSX = 'http://public.numenta.com/releases/htm-studio/darwin/HTM%20Studio-1.0.0.dmg'  // eslint-disable-line max-len

--- a/packages/numenta.com/pages/machine-intelligence-technology/index.jsx
+++ b/packages/numenta.com/pages/machine-intelligence-technology/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionTechnology from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionTechnology key="sectionTechnology" />)
 const title = 'Technology Overview'

--- a/packages/numenta.com/pages/mission-and-history/index.jsx
+++ b/packages/numenta.com/pages/mission-and-history/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionMission from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionMission key="sectionMission" />)
 const title = 'Mission & History'

--- a/packages/numenta.com/pages/neuroscience-research/index.jsx
+++ b/packages/numenta.com/pages/neuroscience-research/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionNeuroscience from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionNeuroscience key="sectionNeuroscience" />)
 const title = 'Neuroscience Research'

--- a/packages/numenta.com/pages/newsletter/index.jsx
+++ b/packages/numenta.com/pages/newsletter/index.jsx
@@ -13,10 +13,11 @@ import FormRow from 'numenta-web-shared-components/lib/FormRow'
 import ListItem from 'numenta-web-shared-components/lib/ListItem'
 import ListOrder from 'numenta-web-shared-components/lib/ListOrder'
 import Section from 'numenta-web-shared-components/lib/Section'
-import {sortDateDescend} from 'numenta-web-shared-utils/lib/shared'
 
 import PostListRow from '../../components/PostListRow'
 import styles from './index.css'
+
+const {sortDateDescend} = require('numenta-web-shared-utils/universal')
 
 const title = 'Newsletter'
 

--- a/packages/numenta.com/pages/open-source-community/index.jsx
+++ b/packages/numenta.com/pages/open-source-community/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionOpensource from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionOpensource key="sectionOpensource" />)
 const title = 'Open Source Community'

--- a/packages/numenta.com/pages/papers-videos-and-more/_Section.jsx
+++ b/packages/numenta.com/pages/papers-videos-and-more/_Section.jsx
@@ -18,10 +18,10 @@ import Subtle from 'numenta-web-shared-components/lib/Subtle'
 import TextLink from 'numenta-web-shared-components/lib/TextLink'
 import Video from 'numenta-web-shared-components/lib/Video'
 
-import {sortDateDescend} from 'numenta-web-shared-utils/lib/shared'
-
 import ImageVideo from './images/video.png'
 import styles from './index.css'
+
+const {sortDateDescend} = require('numenta-web-shared-utils/universal')
 
 const learnIcons = {
   book: (<IconBook />),

--- a/packages/numenta.com/pages/papers-videos-and-more/index.jsx
+++ b/packages/numenta.com/pages/papers-videos-and-more/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionResources from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionResources key="sectionResources" />)
 const title = 'Papers, Videos & More'

--- a/packages/numenta.com/pages/papers/index.jsx
+++ b/packages/numenta.com/pages/papers/index.jsx
@@ -10,12 +10,13 @@ import ListItem from 'numenta-web-shared-components/lib/ListItem'
 import ListOrder from 'numenta-web-shared-components/lib/ListOrder'
 import Paragraph from 'numenta-web-shared-components/lib/Paragraph'
 import Section from 'numenta-web-shared-components/lib/Section'
-import {sortOrderAscend} from 'numenta-web-shared-utils/lib/shared'
 import Spacer from 'numenta-web-shared-components/lib/Spacer'
 import Subtle from 'numenta-web-shared-components/lib/Subtle'
 import TextLink from 'numenta-web-shared-components/lib/TextLink'
 
 import styles from './index.css'
+
+const {sortOrderAscend} = require('numenta-web-shared-utils/universal')
 
 const title = 'Research Papers'
 

--- a/packages/numenta.com/pages/partners/index.jsx
+++ b/packages/numenta.com/pages/partners/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionPartners from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionPartners key="sectionPartners" />)
 const title = 'Partners'

--- a/packages/numenta.com/pages/press/index.jsx
+++ b/packages/numenta.com/pages/press/index.jsx
@@ -10,13 +10,14 @@ import ListItem from 'numenta-web-shared-components/lib/ListItem'
 import ListOrder from 'numenta-web-shared-components/lib/ListOrder'
 import PostListItem from 'numenta-web-shared-components/lib/PostListItem'
 import Section from 'numenta-web-shared-components/lib/Section'
-import {sortDateDescend} from 'numenta-web-shared-utils/lib/shared'
 import Spacer from 'numenta-web-shared-components/lib/Spacer'
 import SubTitle from 'numenta-web-shared-components/lib/SubTitle'
 import Subtle from 'numenta-web-shared-components/lib/Subtle'
 import TextLink from 'numenta-web-shared-components/lib/TextLink'
 
 import styles from './index.css'
+
+const {sortDateDescend} = require('numenta-web-shared-utils/universal')
 
 
 /**

--- a/packages/numenta.com/pages/sitemap/index.jsx
+++ b/packages/numenta.com/pages/sitemap/index.jsx
@@ -10,13 +10,14 @@ import Anchor from 'numenta-web-shared-components/lib/Anchor'
 import ListItem from 'numenta-web-shared-components/lib/ListItem'
 import ListOrder from 'numenta-web-shared-components/lib/ListOrder'
 import Section from 'numenta-web-shared-components/lib/Section'
-import {sortDateDescend} from 'numenta-web-shared-utils/lib/shared'
 import Spacer from 'numenta-web-shared-components/lib/Spacer'
 import SubTitle from 'numenta-web-shared-components/lib/SubTitle'
 import Subtle from 'numenta-web-shared-components/lib/Subtle'
 import TextLink from 'numenta-web-shared-components/lib/TextLink'
 
 import styles from './index.css'
+
+const {sortDateDescend} = require('numenta-web-shared-utils/universal')
 
 const title = 'Sitemap'
 

--- a/packages/numenta.com/wrappers/md.jsx
+++ b/packages/numenta.com/wrappers/md.jsx
@@ -25,11 +25,12 @@ import TableRow from 'numenta-web-shared-components/lib/TableRow'
 import TextLink from 'numenta-web-shared-components/lib/TextLink'
 import Time from 'numenta-web-shared-components/lib/Time'
 import Video from 'numenta-web-shared-components/lib/Video'
-import {
-  getEventTimeDisplay, getVideoIdFromUrl,
-} from 'numenta-web-shared-utils/lib/shared'
 
 import styles from './md.css'
+
+const {
+  getEventTimeDisplay, getVideoIdFromUrl,
+} = require('numenta-web-shared-utils/universal')
 
 const postTypes = [
   'blog', 'careers', 'events', 'newsletter', 'press', 'resources',

--- a/packages/numenta.org/components/Layout/__tests__/__snapshots__/index.unit.test.jsx.snap
+++ b/packages/numenta.org/components/Layout/__tests__/__snapshots__/index.unit.test.jsx.snap
@@ -93,7 +93,7 @@ exports[`Layout React component Renders correctly 1`] = `
         className="footer">
         <span>
           © 
-          2016
+          2017
            
            
           <a

--- a/packages/numenta.org/components/PostListRow/index.jsx
+++ b/packages/numenta.org/components/PostListRow/index.jsx
@@ -4,8 +4,6 @@
 
 import React from 'react'
 
-import {getVideoIdFromUrl} from 'numenta-web-shared-utils/lib/shared'
-
 import Image from 'numenta-web-shared-components/lib/Image'
 import ImageLink from 'numenta-web-shared-components/lib/ImageLink'
 import PostListItem from 'numenta-web-shared-components/lib/PostListItem'
@@ -13,9 +11,11 @@ import Video from 'numenta-web-shared-components/lib/Video'
 
 import styles from './index.css'
 
+const {getVideoIdFromUrl} = require('numenta-web-shared-utils/universal')
+
 
 /**
- *
+ * Numenta.org Post List Row - React view component.
  */
 const PostListRow = ({post}) => {
   const {data, path} = post

--- a/packages/numenta.org/gatsby-browser.js
+++ b/packages/numenta.org/gatsby-browser.js
@@ -3,7 +3,8 @@
 // Copyright © 2005—2017 Numenta <http://numenta.com>
 
 import root from 'window-or-global'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 
 /**

--- a/packages/numenta.org/html.jsx
+++ b/packages/numenta.org/html.jsx
@@ -4,21 +4,24 @@
 
 import {config} from 'config'
 import Helmet from 'react-helmet'
-import moment from 'moment'
 import Pingdom from 'numenta-web-shared-components/lib/Pingdom'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
+import root from 'window-or-global'
 
 const {stampUrl} = require('numenta-web-shared-utils/universal')
 
-global.stamp = moment().unix().toString()
-
 
 /**
- * Main HTML Document Site wrapper - React view component.
+ * Main Numenta.org HTML5 Document skeleton - React view component. Base file
+ *  for Gatsby.js framework.
+ * @author Numenta <info@numenta.com>
+ * @copyright © 2005—2017 Numenta <http://numenta.com>
+ * @license MIT
+ * @requires gatsby react
  */
 const HtmlDocument = ({body}) => {
-  const {stamp} = global
+  const {STAMP} = root
   const {analytics} = config
   const {htmlAttributes, link, meta, title} = Helmet.rewind()
   const attrs = htmlAttributes.toComponent()
@@ -34,7 +37,7 @@ const HtmlDocument = ({body}) => {
       </head>
       <body className="body">
         <div id="react-mount" dangerouslySetInnerHTML={{__html: body}} />
-        <script src={prefixLink(stampUrl('/bundle.js', stamp))} />
+        <script src={prefixLink(stampUrl('/bundle.js', STAMP))} />
       </body>
     </html>
   )

--- a/packages/numenta.org/html.jsx
+++ b/packages/numenta.org/html.jsx
@@ -3,19 +3,22 @@
 // Copyright © 2005—2017 Numenta <http://numenta.com>
 
 import {config} from 'config'
-import {stampUrl} from 'numenta-web-shared-utils/lib/shared'
 import Helmet from 'react-helmet'
+import moment from 'moment'
 import Pingdom from 'numenta-web-shared-components/lib/Pingdom'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
 
-import {version} from './package'
+const {stampUrl} = require('numenta-web-shared-utils/universal')
+
+global.stamp = moment().unix().toString()
 
 
 /**
  * Main HTML Document Site wrapper - React view component.
  */
 const HtmlDocument = ({body}) => {
+  const {stamp} = global
   const {analytics} = config
   const {htmlAttributes, link, meta, title} = Helmet.rewind()
   const attrs = htmlAttributes.toComponent()
@@ -31,7 +34,7 @@ const HtmlDocument = ({body}) => {
       </head>
       <body className="body">
         <div id="react-mount" dangerouslySetInnerHTML={{__html: body}} />
-        <script src={prefixLink(stampUrl('/bundle.js', version))} />
+        <script src={prefixLink(stampUrl('/bundle.js', stamp))} />
       </body>
     </html>
   )

--- a/packages/numenta.org/package.json
+++ b/packages/numenta.org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "numenta-web-site-org",
-  "version": "0.2.22",
+  "version": "0.0.0",
   "description": "Numenta.org HTM Community website content, source code, and static generator tooling",
   "license": "MIT",
   "main": false,

--- a/packages/numenta.org/pages/_MainSections.jsx
+++ b/packages/numenta.org/pages/_MainSections.jsx
@@ -6,7 +6,6 @@ import findIndex from 'lodash/findIndex'
 import React from 'react'
 import root from 'window-or-global'
 
-import {hasSessionStorage} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import SectionCode from './code/_Section'
@@ -14,6 +13,8 @@ import SectionCommunity from './community/_Section'
 import SectionHome from './_Section'
 import SectionHtm from './hierarchical-temporal-memory/_Section'
 import SectionResearch from './research-and-publications/_Section'
+
+const {hasSessionStorage} = require('numenta-web-shared-utils/client')
 
 const mainSectionList = [
   {

--- a/packages/numenta.org/pages/_template.jsx
+++ b/packages/numenta.org/pages/_template.jsx
@@ -13,7 +13,6 @@ import mapValues from 'lodash/mapValues'
 import moment from 'moment'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
-import {stampUrl} from 'numenta-web-shared-utils/lib/shared'
 import values from 'lodash/values'
 
 import Layout from '../components/Layout'
@@ -21,6 +20,8 @@ import manifest from '../package'
 
 import 'tachyons-base/css/tachyons-base.css'  // eslint-disable-line import/first, max-len
 import '../static/assets/css/fonts.css'
+
+const {stampUrl} = require('numenta-web-shared-utils/universal')
 
 
 /**
@@ -37,18 +38,21 @@ class Template extends React.Component {
     config: React.PropTypes.object,
     manifest: React.PropTypes.object,
     route: React.PropTypes.object,
+    stamp: React.PropTypes.string,
   }
 
   getChildContext() {
+    const {stamp} = global
     const {route} = this.props
-    return {config, manifest, route}
+    return {config, manifest, route, stamp}
   }
 
   componentDidMount() {
-    if (global.window) injectTapEventPlugin()  // remove @ React 1.0
+    if ('window' in global) injectTapEventPlugin()  // remove @ React 1.0
   }
 
   render() {
+    const {stamp} = global
     const {children} = this.props
     const {analytics, company, description, siteHost} = config
     const lang = 'en'  // @TODO i18n l10n
@@ -56,7 +60,6 @@ class Template extends React.Component {
     const title = `${siteHost} • ${description}`
     const titleForm = `${siteHost} • %s`
     const icons = flatten(values(mapValues(favicons, (value) => keys(value))))
-    const {version} = manifest
 
     // react-helmet / head
     const attrs = {lang}
@@ -70,7 +73,7 @@ class Template extends React.Component {
       {name: 'keywords', content: title.split(' ').join(',')},
       {
         name: 'generator',
-        content: `© ${siteHost} v${version} ${now} • Gatsby.js`,
+        content: `© ${siteHost} v${stamp} ${now} • Gatsby.js`,
       },
     ]
 
@@ -78,7 +81,7 @@ class Template extends React.Component {
     if (process.env.NODE_ENV === 'production') {
       links.push({
         rel: 'stylesheet',
-        href: prefixLink(stampUrl('/styles.css', version)),
+        href: prefixLink(stampUrl('/styles.css', stamp)),
       })
     }
 

--- a/packages/numenta.org/pages/_template.jsx
+++ b/packages/numenta.org/pages/_template.jsx
@@ -13,6 +13,7 @@ import mapValues from 'lodash/mapValues'
 import moment from 'moment'
 import {prefixLink} from 'gatsby-helpers'
 import React from 'react'
+import root from 'window-or-global'
 import values from 'lodash/values'
 
 import Layout from '../components/Layout'
@@ -23,9 +24,12 @@ import '../static/assets/css/fonts.css'
 
 const {stampUrl} = require('numenta-web-shared-utils/universal')
 
+root.STAMP = moment().unix().toString()  // global! cache-busting id
+
 
 /**
- *
+ * Numenta.org Root Gatsby Template, acts as React-router bridge (per Gatsby),
+ *  and internal Layout and Headmatter manager - a React view component.
  */
 class Template extends React.Component {
 
@@ -42,9 +46,9 @@ class Template extends React.Component {
   }
 
   getChildContext() {
-    const {stamp} = global
+    const {STAMP} = root
     const {route} = this.props
-    return {config, manifest, route, stamp}
+    return {config, manifest, route, stamp: STAMP}
   }
 
   componentDidMount() {
@@ -52,7 +56,7 @@ class Template extends React.Component {
   }
 
   render() {
-    const {stamp} = global
+    const {STAMP} = root
     const {children} = this.props
     const {analytics, company, description, siteHost} = config
     const lang = 'en'  // @TODO i18n l10n
@@ -73,7 +77,7 @@ class Template extends React.Component {
       {name: 'keywords', content: title.split(' ').join(',')},
       {
         name: 'generator',
-        content: `© ${siteHost} v${stamp} ${now} • Gatsby.js`,
+        content: `© ${now} ${siteHost} v=${STAMP} x Gatsby.js`,
       },
     ]
 
@@ -81,7 +85,7 @@ class Template extends React.Component {
     if (process.env.NODE_ENV === 'production') {
       links.push({
         rel: 'stylesheet',
-        href: prefixLink(stampUrl('/styles.css', stamp)),
+        href: prefixLink(stampUrl('/styles.css', STAMP)),
       })
     }
 

--- a/packages/numenta.org/pages/blog/index.jsx
+++ b/packages/numenta.org/pages/blog/index.jsx
@@ -8,9 +8,10 @@ import React from 'react'
 import ListItem from 'numenta-web-shared-components/lib/ListItem'
 import ListOrder from 'numenta-web-shared-components/lib/List'
 import Section from 'numenta-web-shared-components/lib/Section'
-import {sortDateDescend} from 'numenta-web-shared-utils/lib/shared'
 
 import PostListRow from '../../components/PostListRow'
+
+const {sortDateDescend} = require('numenta-web-shared-utils/universal')
 
 const title = 'Blog'
 

--- a/packages/numenta.org/pages/code/index.jsx
+++ b/packages/numenta.org/pages/code/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections from '../_MainSections'
 import SectionCode from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionCode key="sectionCode" />)
 const title = 'Code'

--- a/packages/numenta.org/pages/community/index.jsx
+++ b/packages/numenta.org/pages/community/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionCommunity from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionCommunity key="sectionCommunity" />)
 const title = 'Community'

--- a/packages/numenta.org/pages/hierarchical-temporal-memory/index.jsx
+++ b/packages/numenta.org/pages/hierarchical-temporal-memory/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionHtm from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionHtm key="sectionHtm" />)
 const title = 'Hierarchical Temporal Memory (HTM)'

--- a/packages/numenta.org/pages/papers/index.jsx
+++ b/packages/numenta.org/pages/papers/index.jsx
@@ -10,12 +10,13 @@ import ListItem from 'numenta-web-shared-components/lib/ListItem'
 import ListOrder from 'numenta-web-shared-components/lib/ListOrder'
 import Paragraph from 'numenta-web-shared-components/lib/Paragraph'
 import Section from 'numenta-web-shared-components/lib/Section'
-import {sortOrderAscend} from 'numenta-web-shared-utils/lib/shared'
 import Spacer from 'numenta-web-shared-components/lib/Spacer'
 import Subtle from 'numenta-web-shared-components/lib/Subtle'
 import TextLink from 'numenta-web-shared-components/lib/TextLink'
 
 import styles from './index.css'
+
+const {sortOrderAscend} = require('numenta-web-shared-utils/universal')
 
 const title = 'Research Papers'
 

--- a/packages/numenta.org/pages/research-and-publications/index.jsx
+++ b/packages/numenta.org/pages/research-and-publications/index.jsx
@@ -6,11 +6,12 @@ import Helmet from 'react-helmet'
 import React from 'react'
 
 import NextSection from 'numenta-web-shared-components/lib/NextSection'
-import {scrollToSection} from 'numenta-web-shared-utils/lib/client'
 import Section from 'numenta-web-shared-components/lib/Section'
 
 import MainSections, {getNextSection} from '../_MainSections'
 import SectionResearch from './_Section'
+
+const {scrollToSection} = require('numenta-web-shared-utils/client')
 
 const Default = (<SectionResearch key="sectionResearch" />)
 const title = 'Research & Publications'

--- a/packages/numenta.org/pages/sitemap/index.jsx
+++ b/packages/numenta.org/pages/sitemap/index.jsx
@@ -10,13 +10,14 @@ import Anchor from 'numenta-web-shared-components/lib/Anchor'
 import ListItem from 'numenta-web-shared-components/lib/ListItem'
 import ListOrder from 'numenta-web-shared-components/lib/ListOrder'
 import Section from 'numenta-web-shared-components/lib/Section'
-import {sortDateDescend} from 'numenta-web-shared-utils/lib/shared'
 import Spacer from 'numenta-web-shared-components/lib/Spacer'
 import SubTitle from 'numenta-web-shared-components/lib/SubTitle'
 import Subtle from 'numenta-web-shared-components/lib/Subtle'
 import TextLink from 'numenta-web-shared-components/lib/TextLink'
 
 import styles from './index.css'
+
+const {sortDateDescend} = require('numenta-web-shared-utils/universal')
 
 const title = 'Sitemap'
 

--- a/packages/numenta.org/wrappers/md.jsx
+++ b/packages/numenta.org/wrappers/md.jsx
@@ -18,9 +18,10 @@ import Subtle from 'numenta-web-shared-components/lib/Subtle'
 import TextLink from 'numenta-web-shared-components/lib/TextLink'
 import Time from 'numenta-web-shared-components/lib/Time'
 import Video from 'numenta-web-shared-components/lib/Video'
-import {getVideoIdFromUrl} from 'numenta-web-shared-utils/lib/shared'
 
 import styles from './md.css'
+
+const {getVideoIdFromUrl} = require('numenta-web-shared-utils/universal')
 
 const pluralize = (text) => (text.match(/s$/) ? text : `${text}s`)
 const postTypes = ['blog', 'papers']

--- a/packages/utils/__tests__/client.unit.test.js
+++ b/packages/utils/__tests__/client.unit.test.js
@@ -1,4 +1,4 @@
-import {getBrowserWidth, hasSessionStorage} from '../lib/client'
+const {getBrowserWidth, hasSessionStorage} = require('../client')
 
 
 describe('Client helper utils', () => {

--- a/packages/utils/__tests__/universal.unit.test.js
+++ b/packages/utils/__tests__/universal.unit.test.js
@@ -1,9 +1,9 @@
-import {
+const {
   getModalWidth, getVideoIdFromUrl, stampUrl, trims,
-} from '../lib/shared'
+} = require('../universal')
 
 
-describe('Shared Client+Server helper utils', () => {
+describe('Universal Client+Server helper utils', () => {
 
   describe('getEventTimeDisplay()', () => {
     it('Gets event datetime display', () => {
@@ -37,7 +37,8 @@ describe('Shared Client+Server helper utils', () => {
 
   describe('stampUrl()', () => {
     it('Stamps a cache-buster version number on a URL string', () => {
-      expect(stampUrl('http://numenta.com/', '0.2.43')).toContain('0.2.')
+      const stamp = '1318874398'
+      expect(stampUrl('http://numenta.com/', stamp)).toContain(stamp)
     })
   })
 

--- a/packages/utils/client.js
+++ b/packages/utils/client.js
@@ -2,9 +2,9 @@
 // MIT License (see LICENSE.txt)
 // Copyright © 2005—2017 Numenta <http://numenta.com>
 
-import browserSize from 'browser-size'
-import root from 'window-or-global'
-import url from 'url'
+const browserSize = require('browser-size')
+const root = require('window-or-global')
+const url = require('url')
 
 /**
  * Utils for the Clientside
@@ -15,7 +15,7 @@ import url from 'url'
  * Get current width of browser via DOM API, default to 640px.
  * @returns {Number} - Width of browser in pixels or default.
  */
-export function getBrowserWidth() {
+exports.getBrowserWidth = () => {
   const min = 640
   if (global.window) {
     const {width} = browserSize()
@@ -28,7 +28,7 @@ export function getBrowserWidth() {
  * Check if browser has SessionStorage feature.
  * @returns {Boolean} - True for SessionStorage in browser, False if not.
  */
-export function hasSessionStorage() {
+exports.hasSessionStorage = () => {
   const {sessionStorage} = root
   const mod = '_'
 
@@ -48,7 +48,7 @@ export function hasSessionStorage() {
  * @param {Number} [pad=-60] - Extra padding for precision, default -60 for
  *  static header component.
  */
-export function scrollToSection(element, pad = -60) {
+exports.scrollToSection = (element, pad = -60) => {
   const {scroll, setTimeout} = root
   if (element && 'getBoundingClientRect' in element) {
     const {top} = element.getBoundingClientRect()
@@ -63,7 +63,7 @@ export function scrollToSection(element, pad = -60) {
  * @param {String} href - Target URL event for tracking in GAnalytics
  * @requires react-g-analytics (or equivalent)
  */
-export function triggerGAnalyticsEvent(href) {
+exports.triggerGAnalyticsEvent = (href) => {
   if (!href) return
 
   const {ga} = root

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,23 +21,10 @@
     "window-or-global": "1.0.1"
   },
   "devDependencies": {
-    "babel-cli": "6.18.0",
-    "babel-core": "6.20.0",
-    "babel-plugin-add-module-exports": "0.2.1",
-    "babel-plugin-transform-class-properties": "6.19.0",
-    "babel-preset-es2015": "6.18.0",
-    "babel-preset-react": "6.16.0",
-    "babel-preset-react-hmre": "1.1.1",
-    "babel-preset-stage-0": "6.16.0",
     "shx": "0.2.1"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/numenta/numenta-web"
-  },
-  "scripts": {
-    "clean": "shx rm -rf lib/",
-    "compile": "babel --copy-files --ignore __tests__ --out-dir lib/ --source-maps true src/",
-    "postinstall": "npm run compile"
   }
 }

--- a/packages/utils/universal.js
+++ b/packages/utils/universal.js
@@ -2,11 +2,11 @@
 // MIT License (see LICENSE.txt)
 // Copyright © 2005—2017 Numenta <http://numenta.com>
 
-import {config} from 'config'
-import moment from 'moment'
+const {config} = require('config')
+const moment = require('moment')
 
 /**
- * Utils Shared between Client and Server (Isomorphic, Universal, etc.)
+ * Utils for both Client and Server (AKA Isomorphic, Universal, etc.)
  */
 
 
@@ -21,7 +21,7 @@ import moment from 'moment'
  * @returns {String} - Human-readable beautiful display text.
  * @TODO `when` should be a site-wide class instead of messy custom object.
  */
-export function getEventTimeDisplay(when) {
+exports.getEventTimeDisplay = (when) => {
   const formatDate = config.moments.human
   const formatTime = 'h:mm A'
   const formatBegin = [formatDate]
@@ -61,9 +61,9 @@ export function getEventTimeDisplay(when) {
 }
 
 /**
- *
+ * Figure out ideal width of Popup Modal based on browser width, etc.
  */
-export function getModalWidth(width, options) {
+exports.getModalWidth = (width, options) => {
   const copy = (options && 'copy' in options) ? options.copy : false
   const pad = (options && 'pad' in options) ? options.pad : 120
   let long
@@ -86,14 +86,12 @@ export function getModalWidth(width, options) {
  * @param {String} url - Video URL to get Video ID from, as http://youtu.be/ID
  * @returns {String} - Video ID as parsed from URL
  */
-export function getVideoIdFromUrl(url) {
-  return url.match(/.*\/(.*)$/).pop()
-}
+exports.getVideoIdFromUrl = (url) => url.match(/.*\/(.*)$/).pop()
 
 /**
- *
+ * Sort post by ascending date order.
  */
-export function sortDateAscend(a, b) {
+exports.sortDateAscend = (a, b) => {
   const aDate = moment(a.data.date, config.moments.post)
   const bDate = moment(b.data.date, config.moments.post)
 
@@ -103,9 +101,9 @@ export function sortDateAscend(a, b) {
 }
 
 /**
- *
+ * Sort post by descending date order.
  */
-export function sortDateDescend(a, b) {
+exports.sortDateDescend = (a, b) => {
   const aDate = moment(a.data.date, config.moments.post)
   const bDate = moment(b.data.date, config.moments.post)
 
@@ -115,9 +113,9 @@ export function sortDateDescend(a, b) {
 }
 
 /**
- *
+ * Sort posts by post 'sort' attribute order (alphabetic).
  */
-export function sortOrderAscend(a, b) {
+exports.sortOrderAscend = (a, b) => {
   if (a.data.sort > b.data.sort) return 1
   if (a.data.sort < b.data.sort) return -1
   return 0
@@ -129,9 +127,7 @@ export function sortOrderAscend(a, b) {
  * @param {String} version - Version string ("1.0.2") to use as stamp on URL.
  * @returns {String} - URL with Version stamp.
  */
-export function stampUrl(url, version) {
-  return `${url}?v=${version}`
-}
+exports.stampUrl = (url, version) => `${url}?v=${version}`
 
 /**
  * Template String to trim extra spaces from multiline es6 strings.
@@ -139,7 +135,7 @@ export function stampUrl(url, version) {
  * @param {...Array} [values] - Template string filler values.
  * @returns {String} - Completed and filled string.
  */
-export function trims(strings, ...values) {
+exports.trims = (strings, ...values) => {
   let result = ''
   let i = 0
   let tmp


### PR DESCRIPTION
WEB-34 Wrap up bamboo build and deploy. Simplify code.
Switching from es6 imports to common/node require-style modules, this very
simple change lets us skip transpiling the shared Components and Utils.
https://jira.numenta.com/browse/WEB-34
just FYI @rhyolight 