### PR TITLE
Fix missing style org

### DIFF
--- a/packages/numenta.com/pages/_template.jsx
+++ b/packages/numenta.com/pages/_template.jsx
@@ -19,7 +19,6 @@ import values from 'lodash/values'
 import Layout from '../components/Layout'
 import manifest from '../package'
 
-import styles from '!raw!../public/styles.css'  // eslint-disable-line
 import 'tachyons-base/css/tachyons-base.css'  // eslint-disable-line
 import '../static/assets/css/fonts.css'
 
@@ -80,11 +79,6 @@ class Template extends React.Component {
         content: `© ${now} ${siteHost} v=${STAMP} x Gatsby.js`,
       },
     ]
-
-    // inline production stylesheet bundle
-    if (process.env.NODE_ENV === 'production') {
-      style.push({type: 'text/css', cssText: styles})
-    }
 
     // push auto-generated favicons into react-helmet header link and meta
     icons.forEach((icon) => {

--- a/packages/numenta.org/.gitignore
+++ b/packages/numenta.org/.gitignore
@@ -6,3 +6,6 @@ npm-debug.log
 pages/_searchIndex.json
 public/_searchIndex.json
 public
+
+.idea/
+

--- a/packages/numenta.org/pages/_template.jsx
+++ b/packages/numenta.org/pages/_template.jsx
@@ -19,7 +19,6 @@ import values from 'lodash/values'
 import Layout from '../components/Layout'
 import manifest from '../package'
 
-import styles from '!raw!../public/styles.css'  // eslint-disable-line
 import 'tachyons-base/css/tachyons-base.css'  // eslint-disable-line
 import '../static/assets/css/fonts.css'
 
@@ -80,11 +79,6 @@ class Template extends React.Component {
         content: `© ${now} ${siteHost} v=${STAMP} x Gatsby.js`,
       },
     ]
-
-    // inline production stylesheet bundle
-    if (process.env.NODE_ENV === 'production') {
-      style.push({type: 'text/css', cssText: styles})
-    }
 
     // push auto-generated favicons into react-helmet header link and meta
     icons.forEach((icon) => {


### PR DESCRIPTION
I kept getting errors in both packages in `pages/_template.jsx` that
were looking for a nonexistent "styles.css" file. I imagine it was
removed from source control but still exists on @brev's file system, and
that's why this was overlooked?