### PR TITLE
[EXAMPLE] Example of using more Markdown for main content ?

### DIFF
--- a/packages/numenta.org/pages/hierarchical-temporal-memory/_Section.jsx
+++ b/packages/numenta.org/pages/hierarchical-temporal-memory/_Section.jsx
@@ -5,9 +5,9 @@
 import React from 'react'
 
 import Image from 'numenta-web-shared-components/lib/Image'
-import Paragraph from 'numenta-web-shared-components/lib/Paragraph'
-import TextLink from 'numenta-web-shared-components/lib/TextLink'
+import Markdown from 'numenta-web-shared-components/lib/Markdown'
 
+import ContentHtm from './content/_htm.md'
 import ImageHtm from './images/image.png'
 import styles from './index.css'
 
@@ -16,58 +16,25 @@ import styles from './index.css'
  * Hierarchical Temporal Memory (HTM) MainSection and page - React view
  *  component.
  */
-const SectionHtm = (props, {config}) => {
-  const {links} = config
-
-  return (
-    <article>
-      <div className={styles.columns}>
-        <div className={styles.aside}>
-          <Image
-            alt="HTM Image"
-            border={true}
-            respond="mw"
-            shadow={true}
-            src={ImageHtm}
-          />
-        </div>
-        <div className={styles.content}>
-          <Paragraph lead={true}>
-            Hierarchical Temporal Memory (HTM) is a biologically-constrained
-            theory of intelligence originally described in the book {' '}
-            <em>On Intelligence</em>. HTM is not a Deep Learning or Machine
-            Learning technology. HTM is a machine intelligence framework
-            strictly based on neuroscience and the physiology and interaction of
-            pyramidal neurons in the neocortex of the mammalian brain.
-          </Paragraph>
-          <Paragraph>
-            For detailed information — including educational videos, papers,
-            and community discussions — regarding HTM, please see our {' '}
-            <TextLink to={links.in.school}>
-              HTM School.
-            </TextLink>
-          </Paragraph>
-          <Paragraph>
-            To get an idea of how HTM theory originated, you can read about the
-            created of the Redwood Neuroscience center and Numenta at {' '}
-            <TextLink to={links.in.history}>
-              HTM History.
-            </TextLink>
-          </Paragraph>
-          <Paragraph>
-            To get involved in our community, join {' '}
-            <TextLink to={links.out.forum}>
-              HTM Forum.
-            </TextLink>
-          </Paragraph>
-        </div>
+const SectionHtm = () => (
+  <article>
+    <div className={styles.columns}>
+      <div className={styles.aside}>
+        <Image
+          alt="HTM Image"
+          border={true}
+          respond="mw"
+          shadow={true}
+          src={ImageHtm}
+        />
       </div>
-    </article>
-  )
-}
-
-SectionHtm.contextTypes = {
-  config: React.PropTypes.object,
-}
+      <div className={styles.content}>
+        <Markdown>
+          <div dangerouslySetInnerHTML={{__html: ContentHtm.body}} />
+        </Markdown>
+      </div>
+    </div>
+  </article>
+)
 
 export default SectionHtm

--- a/packages/numenta.org/pages/hierarchical-temporal-memory/content/_htm.md
+++ b/packages/numenta.org/pages/hierarchical-temporal-memory/content/_htm.md
@@ -1,0 +1,20 @@
+---
+---
+
+Hierarchical Temporal Memory (HTM) is a biologically-constrained theory of
+intelligence originally described in the book **On Intelligence<**. HTM is
+not a Deep Learning or Machine Learning technology. HTM is a machine
+intelligence framework strictly based on neuroscience and the physiology and
+interaction of pyramidal neurons in the neocortex of the mammalian brain.
+
+For detailed information — including educational videos, papers,
+and community discussions — regarding HTM, please see our [HTM School][school].
+
+To get an idea of how HTM theory originated, you can read about the creation of
+the Redwood Neuroscience center and Numenta at [HTM History][history].
+
+To get involved in our community, join [HTM Forum][forum].
+
+[school]: /htm-school/
+[history]: /htm-history/
+[forum]: https://discourse.numenta.org/categories


### PR DESCRIPTION
DO NOT MERGE  - EXAMPLE. Please Close when done reviewing.
@rhyolight and @lscheinkman,

Right now, the websites have two main types of pages: `JSX` (main architectural pages, usually 2 columns) and `Markdown` (simple 1 column pages like Blogs, events, etc.)

I wanted to extract large chunks of simple content out of the JSX files, and into child Markdown files. This gives Marketing better access to edit the site, and should simplify changes for everyone (unless bigger changes are required to the JSX).

This is a first draft exploration and example of doing this.  This is one of the big things I wasn't able to get done before handoff.

There are trade-offs to this:
* Must specify URLs manually, don't have access to config variables in the `.md` files
* Links and Styling of these Markdown chunks is one of the weaker parts of the site currently.
  * Styling these chunks is currently a repeated set of CSS which is already covered by our react components:
    * https://github.com/numenta/numenta-web/blob/master/packages/components/src/Markdown/index.css
  * Ideally, in the future, this could be imporved by the Markdown parser translating MD into our custom React components, instead of regular plain HTML. Gatsby team was discussing this somewhere.

So if you like this, please run with it.  Or, hold off, and ponder. thanks.