### PR TITLE
WEB-446 Remove new .org redirects meant for gh-pages hosting

### DIFF
--- a/packages/numenta.org/static/blog/2013/06/03/introducing-nupic.html
+++ b/packages/numenta.org/static/blog/2013/06/03/introducing-nupic.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/06/03/introducing-nupic/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/06/10/hackathon-june-2013.html
+++ b/packages/numenta.org/static/blog/2013/06/10/hackathon-june-2013.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/06/10/hackathon-june-2013/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/06/25/hackathon-outcome.html
+++ b/packages/numenta.org/static/blog/2013/06/25/hackathon-outcome.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/06/25/hackathon-outcome/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/07/01/patent-position.html
+++ b/packages/numenta.org/static/blog/2013/07/01/patent-position.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/07/01/patent-position/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/07/09/predicting-movement-with-ir-sensors.html
+++ b/packages/numenta.org/static/blog/2013/07/09/predicting-movement-with-ir-sensors.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/07/09/predicting-movement-with-ir-sensors/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/08/13/brains-and-machine-intelligence-a-long-time-coming.html
+++ b/packages/numenta.org/static/blog/2013/08/13/brains-and-machine-intelligence-a-long-time-coming.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/08/13/brains-and-machine-intelligence-a-long-time-coming/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/09/03/numenta-contributor-license-v1-1.html
+++ b/packages/numenta.org/static/blog/2013/09/03/numenta-contributor-license-v1-1.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/09/03/numenta-contributor-license-v1-1/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/09/09/numenta-at-oscon.html
+++ b/packages/numenta.org/static/blog/2013/09/09/numenta-at-oscon.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/09/09/numenta-at-oscon/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/11/06/2013-fall-hackathon-outcome.html
+++ b/packages/numenta.org/static/blog/2013/11/06/2013-fall-hackathon-outcome.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/11/06/2013-fall-hackathon-outcome/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/11/11/cla-quiz-office-hour.html
+++ b/packages/numenta.org/static/blog/2013/11/11/cla-quiz-office-hour.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/11/11/cla-quiz-office-hour/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2013/12/16/nupic-commercial-licenses.html
+++ b/packages/numenta.org/static/blog/2013/12/16/nupic-commercial-licenses.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2013/12/16/nupic-commercial-licenses/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2014/03/12/introducing-season-of-nupic.html
+++ b/packages/numenta.org/static/blog/2014/03/12/introducing-season-of-nupic.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2014/03/12/introducing-season-of-nupic/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2014/05/09/2014-spring-hackathon-outcome.html
+++ b/packages/numenta.org/static/blog/2014/05/09/2014-spring-hackathon-outcome.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2014/05/09/2014-spring-hackathon-outcome/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2014/08/08/geospatial-tracking-with-nupic.html
+++ b/packages/numenta.org/static/blog/2014/08/08/geospatial-tracking-with-nupic.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2014/08/08/geospatial-tracking-with-nupic/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2014/08/30/meet-the-nupic-community.html
+++ b/packages/numenta.org/static/blog/2014/08/30/meet-the-nupic-community.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2014/08/30/meet-the-nupic-community/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2014/10/30/2014-fall-hackathon-outcome.html
+++ b/packages/numenta.org/static/blog/2014/10/30/2014-fall-hackathon-outcome.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2014/10/30/2014-fall-hackathon-outcome/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2014/11/24/introducing-nupic-studio.html
+++ b/packages/numenta.org/static/blog/2014/11/24/introducing-nupic-studio.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2014/11/24/introducing-nupic-studio/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2014/12/03/htm-on-the-jvm.html
+++ b/packages/numenta.org/static/blog/2014/12/03/htm-on-the-jvm.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2014/12/03/htm-on-the-jvm/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2015/02/10/htm-java-receives-benchmark-harness.html
+++ b/packages/numenta.org/static/blog/2015/02/10/htm-java-receives-benchmark-harness.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2015/02/10/htm-java-receives-benchmark-harness/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2015/06/08/htm-java-receives-new-network-api.html
+++ b/packages/numenta.org/static/blog/2015/06/08/htm-java-receives-new-network-api.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2015/06/08/htm-java-receives-new-network-api/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2015/08/03/htm-engine-tutorial.html
+++ b/packages/numenta.org/static/blog/2015/08/03/htm-engine-tutorial.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2015/08/03/htm-engine-tutorial/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2015/08/17/licensing-update.html
+++ b/packages/numenta.org/static/blog/2015/08/17/licensing-update.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2015/08/17/licensing-update/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2015/09/18/introducing-the-htm-challenge.html
+++ b/packages/numenta.org/static/blog/2015/09/18/introducing-the-htm-challenge.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2015/09/18/introducing-the-htm-challenge/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2015/11/09/vote-for-the-best-htm-challenge-submissions.html
+++ b/packages/numenta.org/static/blog/2015/11/09/vote-for-the-best-htm-challenge-submissions.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2015/11/09/vote-for-the-best-htm-challenge-submissions/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/blog/2016/02/19/mathmatical-formalization-of-htm-spatial-pooler.html
+++ b/packages/numenta.org/static/blog/2016/02/19/mathmatical-formalization-of-htm-spatial-pooler.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2016/02/19/mathmatical-formalization-of-htm-spatial-pooler/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/committers/index.html
+++ b/packages/numenta.org/static/committers/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/tools/committers/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/contributors/index.html
+++ b/packages/numenta.org/static/contributors/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/tools/contributors/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/docs/index.html
+++ b/packages/numenta.org/static/docs/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/implementations/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/events/2015/03/17/what-the-brain-says-about-machine-intelligence.html
+++ b/packages/numenta.org/static/events/2015/03/17/what-the-brain-says-about-machine-intelligence.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/events/2015/03/17/what-the-brain-says-about-machine-intelligence-nyc-meetup/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/events/2015/03/25/bay-area-nupic-meetup.html
+++ b/packages/numenta.org/static/events/2015/03/25/bay-area-nupic-meetup.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/events/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/events/2015/05/30/nupic-spring-hackathon-2015-nyc.html
+++ b/packages/numenta.org/static/events/2015/05/30/nupic-spring-hackathon-2015-nyc.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/events/2015/05/30/nupic-spring-2015-hackathon/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/events/2016/03/14/bay-area-htm-meetup.html
+++ b/packages/numenta.org/static/events/2016/03/14/bay-area-htm-meetup.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/events/2016/03/14/numenta-htm-bay-area-meetup-santa-clara/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/events/index.html
+++ b/packages/numenta.org/static/events/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/events/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/hack/index.html
+++ b/packages/numenta.org/static/hack/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/events/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/htm/index.html
+++ b/packages/numenta.org/static/htm/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/hierarchical-temporal-memory/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/legal/privacy.html
+++ b/packages/numenta.org/static/legal/privacy.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/legal/privacy/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/legal/terms.html
+++ b/packages/numenta.org/static/legal/terms.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/legal/terms/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/licenses/cl/index.html
+++ b/packages/numenta.org/static/licenses/cl/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/licenses/contrib/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/licenses/code/index.html
+++ b/packages/numenta.org/static/licenses/code/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/licenses/conduct/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/lists/index.html
+++ b/packages/numenta.org/static/lists/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=https://discourse.numenta.org/categories" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2007/05/23/how-brain-science-will-change-computing-ted-2007.html
+++ b/packages/numenta.org/static/media/2007/05/23/how-brain-science-will-change-computing-ted-2007.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2012/05/10/modeling-data-streams-sparse-distributed-representations.html
+++ b/packages/numenta.org/static/media/2012/05/10/modeling-data-streams-sparse-distributed-representations.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2012/06/11/new-insights-from-neuroscience-intelligent-machines.html
+++ b/packages/numenta.org/static/media/2012/06/11/new-insights-from-neuroscience-intelligent-machines.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2012/09/25/computing-like-the-brain-strange-loop-2012.html
+++ b/packages/numenta.org/static/media/2012/09/25/computing-like-the-brain-strange-loop-2012.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2012/10/03/conversations-with-history-on-intelligence.html
+++ b/packages/numenta.org/static/media/2012/10/03/conversations-with-history-on-intelligence.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2012/11/15/recent-advances-in-understanding-how-the-brain-works.html
+++ b/packages/numenta.org/static/media/2012/11/15/recent-advances-in-understanding-how-the-brain-works.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2013/02/13/building-brains-to-understand-the-worlds-data.html
+++ b/packages/numenta.org/static/media/2013/02/13/building-brains-to-understand-the-worlds-data.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2013/04/14/is-our-neocortex-a-giant-semantic-bloom-filter.html
+++ b/packages/numenta.org/static/media/2013/04/14/is-our-neocortex-a-giant-semantic-bloom-filter.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2013/07/22/introduction-to-nupic-at-oscon-2013.html
+++ b/packages/numenta.org/static/media/2013/07/22/introduction-to-nupic-at-oscon-2013.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2013/08/09/where-open-source-and-machine-learning-meet-big-data.html
+++ b/packages/numenta.org/static/media/2013/08/09/where-open-source-and-machine-learning-meet-big-data.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2013/12/05/computing-like-the-brain-path-to-machine-intelligence.html
+++ b/packages/numenta.org/static/media/2013/12/05/computing-like-the-brain-path-to-machine-intelligence.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2013/12/16/notes-yow-2013-jeff-hawkins-path-to-machine-intelligence.html
+++ b/packages/numenta.org/static/media/2013/12/16/notes-yow-2013-jeff-hawkins-path-to-machine-intelligence.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2013/12/30/book-review-on-intelligence-by-jeff-hawkins.html
+++ b/packages/numenta.org/static/media/2013/12/30/book-review-on-intelligence-by-jeff-hawkins.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2014/01/06/from-cortical-microcircuits-to-machine-intelligence.html
+++ b/packages/numenta.org/static/media/2014/01/06/from-cortical-microcircuits-to-machine-intelligence.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2014/01/22/brains-data-and-machine-intelligence.html
+++ b/packages/numenta.org/static/media/2014/01/22/brains-data-and-machine-intelligence.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2014/04/07/jeff-hawkins-twit-tv-leo-laporte.html
+++ b/packages/numenta.org/static/media/2014/04/07/jeff-hawkins-twit-tv-leo-laporte.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2015/04/02/jeff-hawkins-on-firing-up-the-silicon-brain.html
+++ b/packages/numenta.org/static/media/2015/04/02/jeff-hawkins-on-firing-up-the-silicon-brain.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/2015/05/11/perspectives-on-the-future-of-artificial-intelligence.html
+++ b/packages/numenta.org/static/media/2015/05/11/perspectives-on-the-future-of-artificial-intelligence.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/media/index.html
+++ b/packages/numenta.org/static/media/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/press/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/nab/index.html
+++ b/packages/numenta.org/static/nab/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/events/2016/07/24/numenta-anomaly-benchmark-competition-at-ieee-wcci-2016/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2013/08/15/python-2-7-support.html
+++ b/packages/numenta.org/static/news/2013/08/15/python-2-7-support.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2013/08/26/2013-fall-hackathon-announced.html
+++ b/packages/numenta.org/static/news/2013/08/26/2013-fall-hackathon-announced.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2013/09/09/build-artifacts-available.html
+++ b/packages/numenta.org/static/news/2013/09/09/build-artifacts-available.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2013/09/09/swarming-in-nupic-video.html
+++ b/packages/numenta.org/static/news/2013/09/09/swarming-in-nupic-video.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2013/10/29/open-office-hours.html
+++ b/packages/numenta.org/static/news/2013/10/29/open-office-hours.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2013/10/30/nupic-oscon-presentation.html
+++ b/packages/numenta.org/static/news/2013/10/30/nupic-oscon-presentation.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2014/02/12/2014-spring-hackathon-announced.html
+++ b/packages/numenta.org/static/news/2014/02/12/2014-spring-hackathon-announced.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2014/02/12/sensorimotor-integration-in-htm-meetup.html
+++ b/packages/numenta.org/static/news/2014/02/12/sensorimotor-integration-in-htm-meetup.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2014/03/11/get-ready-for-the-season-of-nupic.html
+++ b/packages/numenta.org/static/news/2014/03/11/get-ready-for-the-season-of-nupic.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2014/04/28/son-approved-projects.html
+++ b/packages/numenta.org/static/news/2014/04/28/son-approved-projects.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2014/08/26/mailing-list-failures.html
+++ b/packages/numenta.org/static/news/2014/08/26/mailing-list-failures.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2014/09/05/numenta-training-workshop-announced.html
+++ b/packages/numenta.org/static/news/2014/09/05/numenta-training-workshop-announced.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2015/01/22/nupic-0.1-released.html
+++ b/packages/numenta.org/static/news/2015/01/22/nupic-0.1-released.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/2015/03/11/upcoming-events.html
+++ b/packages/numenta.org/static/news/2015/03/11/upcoming-events.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/news/index.html
+++ b/packages/numenta.org/static/news/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/report/index.html
+++ b/packages/numenta.org/static/report/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=https://github.com/numenta/nupic/issues/new" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/search/index.html
+++ b/packages/numenta.org/static/search/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/son/index.html
+++ b/packages/numenta.org/static/son/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://numenta.com/events/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/stats/index.html
+++ b/packages/numenta.org/static/stats/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/tools/stats/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>

--- a/packages/numenta.org/static/tools/ml-stats.html
+++ b/packages/numenta.org/static/tools/ml-stats.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/tools/" />
-  </head>
-  <body>
-    Resource has moved. Redirecting to new location...
-  </body>
-</html>


### PR DESCRIPTION
WEB-446 Remove new .org redirects meant for gh-pages hosting. Now that we're on S3, redirects are to be handled at bucket level. see WEB-446.

https://jira.numenta.com/browse/WEB-446