### PR TITLE
Embedding echosign docs with iframes

### DIFF
--- a/packages/numenta.org/pages/licenses/contrib.md
+++ b/packages/numenta.org/pages/licenses/contrib.md
@@ -19,7 +19,7 @@ Algorithm (CLA) referenced in our source code and documentation.
 
 ### You may also download the Numenta CL in the following formats:
 
-The embedded document above requires Flash. If it does not show up below, [here is a direct link to the document page](https://secure.na1.echosign.com/public/esignWidget?wid=CBFCIBAA3AAABLblqZhBlxAtRy60dQbf-3OV5_q8O6JzRbnSnmBDMhphe0X2-nxXxCddVIAgu2Y1Cf_0A-eU*). Alternatively, you may fill out this form using one of the formats below and email to <help@numenta.org>.
+The embedded document above requires Flash. If it fails to load, [try this direct link to the document](https://secure.na1.echosign.com/public/esignWidget?wid=CBFCIBAA3AAABLblqZhBlxAtRy60dQbf-3OV5_q8O6JzRbnSnmBDMhphe0X2-nxXxCddVIAgu2Y1Cf_0A-eU*). Alternatively, you may fill out this form using one of the formats below and email to <help@numenta.org>.
 
 * [Plain Text][txt]
 * [PDF][pdf]

--- a/packages/numenta.org/pages/licenses/contrib.md
+++ b/packages/numenta.org/pages/licenses/contrib.md
@@ -9,15 +9,17 @@ Algorithm (CLA) referenced in our source code and documentation.
 
 ### Please read and sign the Numenta Contributor License below:
 
-*Use your **github username** as the optional "Public Name" value.*
+> Use your **github username** as the optional "Public Name" value.
 
 ---
 
-<script src="https://secure.echosign.com/public/embeddedWidget?wid=CBFCIBAA2AAABLblqZhB5rcsG-E9OX4keHHTob72yY2GZtKetGhXxARrVNTTlcPF1Tu9IOlFnCGXNyOhZ96U*"></script>
+<iframe src="https://secure.na1.echosign.com/public/esignWidget?wid=CBFCIBAA3AAABLblqZhBlxAtRy60dQbf-3OV5_q8O6JzRbnSnmBDMhphe0X2-nxXxCddVIAgu2Y1Cf_0A-eU*&hosted=false" width="100%" height="100%" frameborder="0" style="border: 0; overflow: hidden; min-height: 500px; min-width: 600px;"></iframe>
 
 ---
 
 ### You may also download the Numenta CL in the following formats:
+
+The embedded document above requires Flash. If it does not show up below, [here is a direct link to the document page](https://secure.na1.echosign.com/public/esignWidget?wid=CBFCIBAA3AAABLblqZhBlxAtRy60dQbf-3OV5_q8O6JzRbnSnmBDMhphe0X2-nxXxCddVIAgu2Y1Cf_0A-eU*). Alternatively, you may fill out this form using one of the formats below and email to <help@numenta.org>.
 
 * [Plain Text][txt]
 * [PDF][pdf]

--- a/packages/numenta.org/pages/licenses/trial.md
+++ b/packages/numenta.org/pages/licenses/trial.md
@@ -13,7 +13,7 @@ Work under a temporary license to create a proof-of-concept and decide later whe
 
 ### You may also download the Numenta Trial License in the following formats:
 
-The embedded document above requires Flash. If the embedded document does not show up below, [here is a direct link to the document page](https://secure.na1.echosign.com/public/esignWidget?wid=CBFCIBAA3AAABLblqZhA1E2nxUTpvO8y8Zm3cR_4xsyDjIHywL_EyF1i1FcezAW7F2ATd7wbxJlBRgwivwsg*). Alternatively, you may fill out this form using one of the formats below and email to <help@numenta.org>.
+The embedded document above requires Flash. If it fails to load, [try this direct link to the document](https://secure.na1.echosign.com/public/esignWidget?wid=CBFCIBAA3AAABLblqZhA1E2nxUTpvO8y8Zm3cR_4xsyDjIHywL_EyF1i1FcezAW7F2ATd7wbxJlBRgwivwsg*). Alternatively, you may fill out this form using one of the formats below and email to <help@numenta.org>.
 
 * [PDF][pdf]
 * [Plain Text][txt]

--- a/packages/numenta.org/pages/licenses/trial.md
+++ b/packages/numenta.org/pages/licenses/trial.md
@@ -2,7 +2,7 @@
 title: Numenta Trial License
 ---
 
-This license will allow you to work under a temporary license and create a proof-of-concept and decide later whether to convert to a commercial license or go AGPL.
+Work under a temporary license and create a proof-of-concept and decide later whether to convert to a commercial license or go AGPL.
 
 ### Please read and sign the Numenta Trial License document below:
 

--- a/packages/numenta.org/pages/licenses/trial.md
+++ b/packages/numenta.org/pages/licenses/trial.md
@@ -2,7 +2,7 @@
 title: Numenta Trial License
 ---
 
-Work under a temporary license and create a proof-of-concept and decide later whether to convert to a commercial license or go AGPL.
+Work under a temporary license to create a proof-of-concept and decide later whether to convert to a commercial license or go AGPL.
 
 ### Please read and sign the Numenta Trial License document below:
 

--- a/packages/numenta.org/pages/licenses/trial.md
+++ b/packages/numenta.org/pages/licenses/trial.md
@@ -2,15 +2,18 @@
 title: Numenta Trial License
 ---
 
+This license will allow you to work under a temporary license and create a proof-of-concept and decide later whether to convert to a commercial license or go AGPL.
+
 ### Please read and sign the Numenta Trial License document below:
 
 ---
 
-<script src="https://secure.echosign.com/public/embeddedWidget?wid=CBFCIBAA2AAABLblqZhBLTxUqDnhed_-yFSwUwBB72hIfRdvbhCdJVqPi5Ai-HWridyTAheYtHZyRDWq7uwA*"></script>
-
+<iframe src="https://secure.na1.echosign.com/public/esignWidget?wid=CBFCIBAA3AAABLblqZhA1E2nxUTpvO8y8Zm3cR_4xsyDjIHywL_EyF1i1FcezAW7F2ATd7wbxJlBRgwivwsg*&hosted=false" width="100%" height="100%" frameborder="0" style="border: 0; overflow: hidden; min-height: 500px; min-width: 600px;"></iframe>
 ---
 
 ### You may also download the Numenta Trial License in the following formats:
+
+The embedded document above requires Flash. If the embedded document does not show up below, [here is a direct link to the document page](https://secure.na1.echosign.com/public/esignWidget?wid=CBFCIBAA3AAABLblqZhA1E2nxUTpvO8y8Zm3cR_4xsyDjIHywL_EyF1i1FcezAW7F2ATd7wbxJlBRgwivwsg*). Alternatively, you may fill out this form using one of the formats below and email to <help@numenta.org>.
 
 * [PDF][pdf]
 * [Plain Text][txt]


### PR DESCRIPTION
Addresses:
- https://jira.numenta.com/browse/WEB-472
- https://jira.numenta.com/browse/WEB-474
- https://jira.numenta.com/browse/WEB-476

Added better instructional text on both pages with embeddings,
explaining what to do if there is no Flash, and how to get to the direct
signing page if the embedding doesn't load.

Switched from javascript embed (not loading on localhost or staging) to
an iframe embed, which loaded in all environments.