### PR TITLE
[WEB-486] trick html generator to skip dropcap

### DIFF
--- a/packages/numenta.org/pages/licenses/contrib.md
+++ b/packages/numenta.org/pages/licenses/contrib.md
@@ -2,6 +2,8 @@
 title: "Numenta Contributor License (CL)"
 ---
 
+<p></p>
+
 Although most open source projects refer to a "Contributor License Agreement
 (CLA)", we have chosen to refer to this agreement as Numenta's "Contributor
 License (CL)" to prevent confusion between it and the Cortical Learning

--- a/packages/numenta.org/pages/licenses/trial.md
+++ b/packages/numenta.org/pages/licenses/trial.md
@@ -2,6 +2,8 @@
 title: Numenta Trial License
 ---
 
+<p></p>
+
 Work under a temporary license to create a proof-of-concept and decide later whether to convert to a commercial license or go AGPL.
 
 ### Please read and sign the Numenta Trial License document below:


### PR DESCRIPTION
Injected `<p></p>` because only the first paragraph on each paged is dropcapped.

fixes https://jira.numenta.com/browse/WEB-486