### PR TITLE
WEB-833: Add script field to blogs

### DIFF
--- a/packages/numenta.com/wrappers/md.jsx
+++ b/packages/numenta.com/wrappers/md.jsx
@@ -90,7 +90,7 @@ class MarkdownWrapper extends React.Component {
     const occur = datetime.format(config.moments.human)
     let url = Object.values(links.in)
                       .filter((p) => p.length > 1 && path.startsWith(p))[0]
-    let author, back, event, media, header, parent, breadcrumb
+    let author, back, event, media, header, parent, breadcrumb, scripts
     let description = data.description
 
     // Fix breadcrumb text
@@ -317,11 +317,15 @@ class MarkdownWrapper extends React.Component {
         )
       }
     }
+    if ('scripts' in data) {
+      scripts = data.scripts.map((src) => (<script src={src} async="true" />))
+    }
 
     return (
       <article className={data.columns ? styles.mdCol : styles.md}>
         <Helmet title={data.title}>
           {getMetadataTags(data, config.baseUrl, {description})}
+          {scripts}
         </Helmet>
         {header}
         <Section


### PR DESCRIPTION
@rhyolight Please review.
Just add the `scripts` field to the blog and the template will add it to the <head>
For example:

```
---
author: Matthew Taylor
description: "Grid cells are cool"
date: 2018/05/17
hideImage: true
org: Open Source Community Manager
keywords: "grid cells"
title: "How Grid Cells Map Space"
header: "How Grid Cells Map Space"
type: post
scripts: 
 - https://code.jquery.com/jquery-3.3.1.slim.min.js
 - https://d3js.org/d3.v5.min.js
 - https://htm-community.github.io/building-htm-systems/bhtms-how-do-grid-cells-work-0.2.2.js
---
```

Tested with PR #509 

----
> *NOTE:*  It won't work with `npm run dev` command. You must use `npm run serve` instead